### PR TITLE
Added Starship Page to display Starship Details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Home from "./pages/home/Home";
 import Person from "./pages/person/Person";
+import Starship from "./pages/starship/Starship";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
@@ -20,6 +21,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/person/:id" element={<Person />} />
+            <Route path="/starship/:id" element={<Starship />} />
           </Routes>
         </QueryClientProvider>
       </BrowserRouter>

--- a/src/api/FetchStarships.js
+++ b/src/api/FetchStarships.js
@@ -1,7 +1,9 @@
-export const fetchStarships = async ({ queryKey }) => {
-  const url = queryKey[1];
+import { BASE_URL } from "../constants/ApiConstants";
 
-  const res = await fetch(`${url}`);
+export const fetchStarships = async ({ queryKey }) => {
+  const id = queryKey[1];
+
+  const res = await fetch(`${BASE_URL}starships/${id}`);
 
   if (!res.ok) {
     throw new Error("somthing went wrong while fetching starships");

--- a/src/components/DetailedPersonCard.jsx
+++ b/src/components/DetailedPersonCard.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useQuery } from "@tanstack/react-query";
 import { fetchSpecie } from "../api/FetchSpecies";
 import { faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "react-router-dom";
 
 function DetailedPersonCard({
   name,
@@ -125,7 +126,9 @@ function DetailedPersonCard({
           </div>
           <div className="flex flex-col justify-between text-lg">
             {starships.map((starship) => (
-              <div className="flex text-lg text-white" key={starship}>{starship}</div>
+              <Link to={`/starship/${starship.url.split("/").slice(-2, -1)[0]}`}>
+              <div className="flex text-lg text-white hover:underline" key={starship.name}>{starship.name}</div>
+              </Link>
             ))}
           </div>
         </div>

--- a/src/components/DetailedStarshipCard.jsx
+++ b/src/components/DetailedStarshipCard.jsx
@@ -1,0 +1,145 @@
+import { faSpaceAwesome } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function DetailedStarshipCard({
+  name,
+  model,
+  starship_class,
+  manufacturer,
+  cost_in_credits,
+  length,
+  crew,
+  passengers,
+  max_atmosphering_speed,
+  hyperdrive_rating,
+  MGLT,
+  cargo_capacity,
+  consumables,
+  noOfFilms,
+  films,
+  noOfPilots,
+  pilots,
+}) {
+  return (
+    <div className="flex w-full flex-col items-start justify-start gap-4 rounded p-4 shadow-lg shadow-slate-800">
+      <div className="flex items-center gap-4 self-stretch border-b-4 border-green-500 p-4">
+        {
+          <FontAwesomeIcon
+            className="h-20 w-20"
+            icon={faSpaceAwesome}
+            beatFade
+            style={{ color: "#f7eded" }}
+          />
+        }
+        <div className="flex flex-grow flex-col justify-start">
+          <div className="text-4xl font-bold tracking-wide text-green-500">
+            {name}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex text-2xl text-green-300">General Details</div>
+
+      <div className="flex flex-col justify-between text-lg">
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Model:</span>{" "}
+          <span className="text-white">{model}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Starship Class:</span>{" "}
+          <span className="capitalize text-white">{starship_class}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Manufacturer:</span>{" "}
+          <span className="capitalize text-white">{manufacturer}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Cost:</span>{" "}
+          <span className="capitalize text-white">{`${cost_in_credits} credits`}</span>
+        </div>
+      </div>
+
+      <div className="flex text-2xl text-green-300">Capacity</div>
+
+      <div className="flex flex-col justify-between text-lg">
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Crew:</span>{" "}
+          <span className="text-white">{`${crew} minimum required`}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Passengers:</span>{" "}
+          <span className="capitalize text-white">{`${passengers} maximum`}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Cargo Capacity:</span>{" "}
+          <span className="capitalize text-white">{`${cargo_capacity} kilograms`}</span>
+        </div>
+      </div>
+
+      <div className="flex text-2xl text-green-300">Specs</div>
+
+      <div className="flex flex-col justify-between text-lg">
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Length:</span>{" "}
+          <span className="capitalize text-white">{`${length} meters`}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Hyperdrive Rating:</span>{" "}
+          <span className="capitalize text-white">{hyperdrive_rating}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">
+            Max Atmosphering Speed:
+          </span>{" "}
+          <span className="capitalize text-white">
+            {max_atmosphering_speed}
+          </span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">Consumables:</span>{" "}
+          <span className="capitalize text-white">{consumables}</span>
+        </div>
+        <div className="flex text-lg">
+          <span className="font-light text-gray-400">MGLT:</span>{" "}
+          <span className="capitalize text-white">{MGLT}</span>
+        </div>
+      </div>
+
+      {noOfFilms > 0 && (
+        <div>
+          <div className="flex text-2xl text-green-300">
+            Films ({noOfFilms})
+          </div>
+          <div className="flex flex-col justify-between text-lg">
+            {films.map((film) => {
+              return (
+                <div className="flex text-lg text-white" key={film}>
+                  {film}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {noOfPilots > 0 && (
+        <div>
+          <div className="flex text-2xl text-green-300">
+            Pilots ({noOfPilots})
+          </div>
+          <div className="flex flex-col justify-between text-lg">
+            {pilots.map((pilot) => {
+              return (
+                <div className="flex text-lg text-white" key={pilot}>
+                  {pilot}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DetailedStarshipCard;

--- a/src/pages/person/Person.jsx
+++ b/src/pages/person/Person.jsx
@@ -23,7 +23,7 @@ function Person() {
     queries: person.isSuccess
       ? person.data.starships.map((starshipUrl) => {
           return {
-            queryKey: ["starship", starshipUrl],
+            queryKey: ["starship", starshipUrl.split("/").slice(-2, -1)[0]],
             queryFn: fetchStarships,
             enabled: !!person.data,
           };
@@ -121,7 +121,10 @@ function Person() {
                   skin_color={person.data.skin_color}
                   species={person.data.species}
                   noOfStarship={person.data.starships.length}
-                  starships={starships.map((starship) => starship.data.name)}
+                  starships={starships.map((starship) => ({
+                    name: starship.data.name,
+                    url: starship.data.url,
+                  }))}
                   noOfVehicles={person.data.vehicles.length}
                   vehicles={vehicles.map((vehicle) => vehicle.data.name)}
                   noOfFilms={person.data.films.length}

--- a/src/pages/starship/Starship.jsx
+++ b/src/pages/starship/Starship.jsx
@@ -1,0 +1,122 @@
+import { useParams } from "react-router-dom";
+import Nav from "../../components/Nav";
+import DetailedStarshipCard from "../../components/DetailedStarshipCard";
+import { useQuery, useQueries } from "@tanstack/react-query";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAndroid } from "@fortawesome/free-brands-svg-icons";
+import { fetchStarships } from "../../api/FetchStarships";
+import { fetchFilms } from "../../api/FetchFilms";
+import { fetchPerson } from "../../api/FetchPerson";
+
+function Starship() {
+  const { id } = useParams();
+  const starship = useQuery(["starship", id], fetchStarships);
+  const person = useQueries({
+    queries: starship.isSuccess
+      ? starship.data.pilots.map((pilotUrl) => {
+          return {
+            queryKey: ["film", pilotUrl.split("/").slice(-2, -1)[0]],
+            queryFn: fetchPerson,
+            enabled: !!starship.data,
+          };
+        })
+      : [],
+  });
+
+  const films = useQueries({
+    queries: starship.isSuccess
+      ? starship.data.films.map((filmUrl) => {
+          return {
+            queryKey: ["film", filmUrl],
+            queryFn: fetchFilms,
+            enabled: !!starship.data,
+          };
+        })
+      : [],
+  });
+
+  const isMultiQueriesSuccess = [films, person].every((queries) =>
+  queries.every((query) => query.isSuccess)
+);
+
+  const isMultiQueriesError = [films, person].some((queries) =>
+  queries.some((query) => query.isError)
+);
+
+  const noStarshipFound = (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4">
+      <FontAwesomeIcon
+        className="h-10 w-12"
+        icon={faAndroid}
+        bounce
+        style={{ color: "#d35555" }}
+      />
+      <div className="text-gray-400">No match found try something else.</div>
+    </div>
+  );
+
+  const loadingData = (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4">
+      <FontAwesomeIcon
+        className="h-12 w-12"
+        icon={faAndroid}
+        fade
+        style={{ color: "#519a5d" }}
+      />
+      <div className="text-gray-400">Finding your request in Archive.</div>
+    </div>
+  );
+
+  return (
+    <div>
+      <Nav />
+      <div className="w-100% flex flex-col items-start justify-start gap-4 overflow-hidden overflow-y-auto overflow-x-hidden bg-slate-700 pr-5 pt-16">
+        <div className="flex h-screen w-full items-start justify-start gap-4 overflow-y-auto overflow-x-hidden">
+          <div className="relative flex h-full w-10 items-center justify-around">
+            <div className="absolute top-[150px] w-56 rotate-[-90deg] transform-gpu	overflow-hidden text-justify align-baseline text-sm font-normal tracking-wider text-green-500 antialiased">
+              {starship.error || isMultiQueriesError
+                ? `No starship found`
+                : starship.isLoading || !isMultiQueriesSuccess
+                ? "Loading..."
+                : `Results of ${starship.data.name}`}
+            </div>
+            <div className="absolute right-0 h-full w-1 bg-green-500"></div>
+          </div>
+          <div className="flex w-full flex-col">
+            <div className="flex flex-wrap items-start justify-center gap-10">
+              {starship.error || isMultiQueriesError ? (
+                noStarshipFound
+              ) : starship.isLoading ||
+                !isMultiQueriesSuccess ? (
+                loadingData
+              ) : (
+                <DetailedStarshipCard
+                  key={starship.data.name}
+                  name={starship.data.name}
+                  model={starship.data.model}
+                  starship_class={starship.data.starship_class}
+                  manufacturer={starship.data.manufacturer}
+                  cost_in_credits={starship.data.cost_in_credits}
+                  length={starship.data.length}
+                  crew={starship.data.crew}
+                  passengers={starship.data.passengers}
+                  max_atmosphering_speed={starship.data.max_atmosphering_speed}
+                  hyperdrive_rating={starship.data.hyperdrive_rating}
+                  MGLT={starship.data.MGLT}
+                  cargo_capacity={starship.data.cargo_capacity}
+                  consumables={starship.data.consumables}
+                  noOfFilms={starship.data.films.length}
+                  films={films.map((film) => film.data.title)}
+                  noOfPilots={starship.data.pilots.length}
+                  pilots={person.map((pilot) => pilot.data.name)}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Starship;


### PR DESCRIPTION
Created a page to display detailed information about a starship. `Films` and `Pilots` subheadings will only be shown if there is available data from [SWAPI](https://swapi.dev/documentation). Users can click on a starship name for a character on the Person Description page to be redirected to this Starship page.

I have also updated the starship API to fetch with an `id' parameter.

This will resolve #5 if you don't have any issues with it.

Displayed information for "X-Wing":
![starship](https://github.com/Leo5661/Starwar-Archive/assets/91957448/df88a874-85ee-4f2e-a6b7-fd5afe1270fa)
